### PR TITLE
feat(mcp): integrate tutor MCP server with nanobot

### DIFF
--- a/.qwen/settings.json
+++ b/.qwen/settings.json
@@ -1,0 +1,7 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(mkdir *)"
+    ]
+  }
+}

--- a/nanobot/entrypoint.py
+++ b/nanobot/entrypoint.py
@@ -90,6 +90,10 @@ def main():
         },
     }
 
+    # Configure mcp_tutor MCP server for the tutor question database
+    if tutor_db_path := os.environ.get("TUTOR_DB_PATH"):
+        config["tools"]["mcpServers"]["tutor"]["env"]["TUTOR_DB_PATH"] = tutor_db_path
+
     # Write resolved config
     with open(resolved_path, "w") as f:
         json.dump(config, f, indent=2)

--- a/nanobot/pyproject.toml
+++ b/nanobot/pyproject.toml
@@ -7,6 +7,7 @@ requires-python = "==3.14.*"
 dependencies = [
     "mcp-lms",
     "mcp-obs",
+    "mcp-tutor",
     "mcp-webchat",
     "nanobot-ai",
     "nanobot-webchat",
@@ -16,6 +17,7 @@ dependencies = [
 nanobot-ai = { url = "https://github.com/HKUDS/nanobot/archive/e7d371ec1e6531b28898ec2c869ef338e8dd46ec.zip" }
 mcp-lms = { workspace = true, editable = true }
 mcp-obs = { workspace = true, editable = true }
+mcp-tutor = { workspace = true, editable = true }
 mcp-webchat = { workspace = true, editable = true }
 nanobot-webchat = { workspace = true, editable = true }
 nanobot-channel-protocol = { workspace = true, editable = true }

--- a/nanobot/workspace/skills/tutor/SKILL.md
+++ b/nanobot/workspace/skills/tutor/SKILL.md
@@ -1,0 +1,113 @@
+---
+name: tutor
+description: Use the tutor MCP tools to run an adaptive quiz session — ask questions, check answers, and track topics
+always: true
+---
+
+# Tutor Skill
+
+You have access to a tutor question database via MCP tools. Use these tools to run adaptive quiz sessions: ask questions, check student answers, and help them learn.
+
+## Available Tools
+
+| Tool | Parameters | Description |
+|------|------------|-------------|
+| `get_all_topics` | none | List all available question topics |
+| `get_random_question` | `topic` (optional) | Get a random question, optionally filtered by topic |
+| `check_answer` | `question_id` (required), `user_answer` (required) | Check a student's answer against the correct answer |
+
+## Strategy
+
+### Adaptive quiz flow
+
+When the user wants to practice or be quizzed:
+
+1. **Ask about preferences** — "Do you want questions from a specific topic, or mixed?" If unsure, show topics via `get_all_topics`.
+2. **Get a question** — Call `get_random_question` (with `topic` if specified).
+3. **Present the question** — Show the question text to the user clearly. Optionally mention the topic.
+4. **Wait for the answer** — Do NOT call `check_answer` until the user provides an answer. Wait for their response.
+5. **Check the answer** — Call `check_answer` with `question_id` and the user's answer text.
+6. **Give feedback** — Report the `keyword_overlap_score` and explain what they got right or missed. Compare their answer to the correct answer.
+7. **Continue or stop** — Ask if they want another question.
+
+### Example: Start a quiz
+
+```
+User: I want to practice
+Assistant: [calls get_all_topics]
+Assistant: Available topics:
+  - Algorithms
+  - Data Structures
+  - DevOps
+  - Memory
+  - Web
+
+Which topic would you like to practice? Or say "mixed" for random topics.
+```
+
+### Example: Ask a question
+
+```
+User: Algorithms please
+Assistant: [calls get_random_question with topic="Algorithms"]
+Assistant: Here's your question (topic: Algorithms):
+
+**What is recursion?**
+
+Take your time and write your answer when ready.
+```
+
+### Example: Check an answer
+
+```
+User: Recursion is when a function calls itself until it reaches a base case
+Assistant: [calls check_answer with question_id=1, user_answer="Recursion is when a function calls itself until it reaches a base case"]
+Assistant: Correct! Your answer matches the expected answer closely.
+
+Keyword overlap score: 1.0 (100%)
+
+Well done! Want another question?
+```
+
+### Example: Partial answer
+
+```
+User: It's a function that repeats
+Assistant: [calls check_answer with question_id=1, user_answer="It's a function that repeats"]
+Assistant: Partially correct! The keyword overlap score is 0.22.
+
+Your answer: "It's a function that repeats"
+Expected: "Recursion is a function calling itself until it reaches a base case"
+
+Key concepts you missed: calling itself, base case. The idea of repetition is right, but recursion specifically means a function **calls itself** and needs a **base case** to stop.
+
+Want to try rephrasing, or shall we move to another question?
+```
+
+### Answer checking behavior
+
+The `check_answer` tool returns a `keyword_overlap_score` (0.0–1.0) based on word overlap with the correct answer. Use this to guide your feedback:
+
+- **0.8–1.0:** Correct or nearly correct — confirm and explain any small differences.
+- **0.4–0.7:** Partially correct — acknowledge what's right, point out what's missing.
+- **0.0–0.3:** Incorrect or too vague — explain the correct answer and key concepts.
+
+**Important:** Do NOT judge correctness yourself based on your own knowledge. Always call `check_answer` and use the returned score. The tool may be upgraded to use LLM-based semantic comparison in the future, so relying on it keeps your behavior consistent.
+
+### Response style
+
+- **Be encouraging** — praise correct answers, be constructive with incorrect ones.
+- **Keep it concise** — short feedback, focus on learning.
+- **Explain, don't just score** — tell the user what they missed and why it matters.
+- **Offer next steps** — "Want another question?", "Try rephrasing?", "Shall we switch topics?"
+
+### When asked "what can you do?"
+
+Explain your tutor capabilities clearly:
+
+> I can help you practice with quiz questions from the tutor database:
+> - Show available topics (Algorithms, Data Structures, DevOps, Memory, Web)
+> - Ask you questions from a specific topic or mixed
+> - Check your answers and give feedback
+>
+> Just say you'd like to practice or ask me about a topic.


### PR DESCRIPTION
 
     3 - Add mcp-tutor dependency to nanobot/pyproject.toml
     4 - Register tutor MCP server in nanobot/config.json with TUTOR_DB_PATH env
     5 - Inject TUTOR_DB_PATH in entrypoint.py for Docker deployments
     6 - Create workspace/skills/tutor/SKILL.md teaching the agent adaptive quiz flow

<!-- Provide a general summary of your changes in the Title above -->

## Summary

<!-- What does this PR do?

Replace <issue-number> with the number of the corresponding task issue.

Add more details if necessary.
-->
Wires the `mcp-tutor` server (get_random_question, check_answer, get_all_topics) into nanobot so the agent can run adaptive quiz sessions. Added a tutor skill prompt that teaches the agent how to present topics, ask questions, check answers with feedback, and continue the quiz flow.

- Closes #4

---
