### PR TITLE
fix: use server_default=func.now() for answered_at timestamp

### DIFF
--- a/mcp/mcp-tutor/src/mcp_tutor/server.py
+++ b/mcp/mcp-tutor/src/mcp_tutor/server.py
@@ -64,9 +64,7 @@ class UserProgress(Base):
     score = Column(Float, nullable=False)  # 0.0–1.0
     user_answer = Column(Text, nullable=False)
     feedback = Column(Text, nullable=True)
-    answered_at = Column(
-        DateTime, nullable=False, default=lambda: datetime.now(timezone.utc)
-    )
+    answered_at = Column(DateTime(timezone=True), server_default=func.now())
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

## Summary

<!-- What does this PR do?

Replace <issue-number> with the number of the corresponding task issue.

Add more details if necessary.
-->

- Closes #35 

---
